### PR TITLE
Moved prefix and token to a separate config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 .idea/
-settings.json
+config.json
 db.json
 logs/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Splatoon 2 Discord Bot
+
+This is a simple discord bot that features the abilities to output every stage/weapon currently in the game, provide random weapons, and provide random stages - including splatfest stages!
+
+## Installation
+
+To clone and run this repository you'll need [Git](https://git-scm.com) and [Node.js](https://nodejs.org) (which comes with [npm](https://npmjs.com)) installed on your computer. From your command line:
+
+```bash
+# Clone this repository
+git clone https://github.com/TheTechdoodle/splatoon-bot.git
+# Go into the repository
+cd splatoon-bot
+# Install dependencies
+npm install
+# Run the app
+npm start
+```
+Please note you'll need to create a `config.json` file to store your bot's unique token and your desired prefix. Create this file in the main directory, and add to it:
+```json
+{"prefix":"_any prefix_","token":"Your bot's token"}
+```
+You can get your bot's token from discord's [developer page](https://discordapp.com/developers/applications).
+## Usage
+
+**Commands:**
+- help - Shows the help message
+- togglemaps - Toggles whether to provide updates in the current channel when maps rotate
+- weapons - Lists all weapons currently in Splatoon 2
+- randomweapon - Get a random weapon
+- stages - Lists all stages currently in Splatoon 2, including splatfest stages
+- randomstage - Gets a random stage from any catagory (default is regular). Options are regular, splatfest, and salmon.
+
+## Contributing
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+[MIT](https://choosealicense.com/licenses/mit/)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const StagesLibrary = require('./src/StagesLibrary');
 const SalmonRunLibrary = require('./src/SalmonRunLibrary');
 const {createLogger, format, transports} = require('winston');
 const {combine, timestamp, label, prettyPrint, printf} = format;
+const config = require("./config.json");
 require('winston-daily-rotate-file');
 
 // Begin logging
@@ -40,17 +41,6 @@ const stagesLibrary = new StagesLibrary(db, logger);
 const mapsLibrary = new MapsLibrary(logger);
 const salmonRunLibrary = new SalmonRunLibrary(logger);
 
-let token = '';
-try
-{
-    token = JSON.parse(fs.readFileSync('settings.json').toString())['token'];
-}
-catch(e)
-{
-    logger.error('Error loading settings.json');
-    logger.error(e);
-    return;
-}
 let client = new Discord.Client();
 
 const stageKeys = {
@@ -114,7 +104,7 @@ function weaponsToString(weapons)
 function sendSalmonRunData(data)
 {
     logger.info("Sending salmon run data");
-    
+
     let now = data['details'][0];
     const future = data['details'][1];
     let embed = new Discord.MessageEmbed()
@@ -134,7 +124,7 @@ function sendMapData(data)
 {
     logger.info("Sending map data");
     let send = [];
-    
+
     // Define the data we want to display
     let scrapeInfo = [
         {
@@ -159,7 +149,7 @@ function sendMapData(data)
             color: 'CDDC39'
         }
     ];
-    
+
     // Loop over the data we want to display
     for(let scrape of scrapeInfo)
     {
@@ -167,7 +157,7 @@ function sendMapData(data)
             .setTitle(scrape.title)
             .setThumbnail(scrape.thumbnail)
             .setColor(scrape.color);
-        
+
         // Add current data
         let now = data[scrape.key][0];
         if(scrape.show_game_mode)
@@ -179,10 +169,10 @@ function sendMapData(data)
         {
             embed.addField("\u200C", "\u200C", true);
         }
-        
+
         // Add blank space
         embed.addField("\u200C", "\u200C");
-        
+
         // Add next data
         let next = data[scrape.key][1];
         if(scrape.show_game_mode)
@@ -194,10 +184,10 @@ function sendMapData(data)
         {
             embed.addField("\u200C", "\u200C", true);
         }
-        
+
         send.push(embed);
     }
-    
+
     // Add a message for the time until refresh
     let timeUntil = mapsLibrary.getRefreshInSimple();
     let timeText = timeUntil.hours + ' Hour' + (timeUntil.hours > 1 ? 's' : '');
@@ -208,7 +198,7 @@ function sendMapData(data)
     let embed = new Discord.MessageEmbed()
         .setTitle('Refresh in ' + timeText);
     send.push(embed);
-    
+
     // Send this data to all servers with the update toggled
     sendToAllServers(send);
 }
@@ -221,7 +211,7 @@ db.defaults({
 client.on('ready', () =>
 {
     logger.info('Logged in as "' + client.user.tag + '"');
-    
+
     // Start the timer to send the messages
     mapsLibrary.on('data', (data) =>
     {
@@ -229,7 +219,7 @@ client.on('ready', () =>
         sendMapData(data);
     });
     mapsLibrary.load();
-    
+
     salmonRunLibrary.on('data', (data) =>
     {
         logger.info('Got salmon run data');
@@ -258,7 +248,7 @@ client.on('message', (message) =>
             }
         });
     }
-    
+
     if(message.content === '!stages')
     {
         // Send a list of stages
@@ -268,7 +258,7 @@ client.on('message', (message) =>
             let stagesEmbed = new Discord.MessageEmbed()
                 .setTitle('All Splatoon 2 Stages:')
                 .setColor(5504768);
-            
+
             let scrapeData = [
                 {
                     name: 'Regular Stages',
@@ -287,7 +277,7 @@ client.on('message', (message) =>
                     key: 'stages_station'
                 }
             ];
-            
+
             // Format the data by category (defined in scrapeData)
             for(let scrape of scrapeData)
             {
@@ -302,11 +292,11 @@ client.on('message', (message) =>
                 }
                 stagesEmbed.addField(scrape.name, stagesList);
             }
-            
+
             message.channel.send(stagesEmbed).catch(logger.error);
         });
     }
-    
+
     if(message.content.startsWith('!randomstage'))
     {
         logger.info(`Sending random stage to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
@@ -317,7 +307,7 @@ client.on('message', (message) =>
             let arg = message.content.substring(13);
             key = stageKeys.hasOwnProperty(arg) ? stageKeys[arg] : null;
         }
-        
+
         if(key == null)
         {
             message.reply('Invalid category. Options are: reg, regular, splat, splatfest, salmon, salmonrun, and station');
@@ -328,25 +318,25 @@ client.on('message', (message) =>
             stagesLibrary.getStages((err, data) =>
             {
                 let maps = data[key];
-                
+
                 let randomMap = maps[Math.floor(Math.random() * maps.length)];
                 message.reply('Your stage is **' + randomMap['name'] + '**');
             });
         }
     }
-    
+
     if(message.content === '!randomweapon')
     {
         logger.info(`Sending random weapon to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
         weaponsLibrary.getWeapons((err, data) =>
         {
             let weapons = data['weapons']['weapons'];
-            
+
             let randomWeapon = weapons[Math.floor(Math.random() * weapons.length)];
             message.reply('Your weapon is the **' + randomWeapon.name + '**');
         });
     }
-    
+
     if(message.content === '!togglemaps')
     {
         // Make sure that if this is a server, only allow the owner to modify this
@@ -359,7 +349,7 @@ client.on('message', (message) =>
                 return;
             }
         }
-        
+
         if(db.get('mapChannels').value().indexOf(message.channel.id) === -1)
         {
             logger.info("Added map updates to " + message.channel.name + " (" + message.channel.id + ")");
@@ -374,7 +364,7 @@ client.on('message', (message) =>
         }
         logger.info(`{On ${message.guild.name} (${message.guild.id})}`);
     }
-    
+
     if(message.content === '!help')
     {
         let msgData = [
@@ -396,7 +386,7 @@ client.on('message', (message) =>
     }
 });
 
-client.login(token).then(r => logger.info('Logged in successfully')).catch(e =>
+client.login(config.token).then(r => logger.info('Logged in successfully')).catch(e =>
 {
     logger.error('Error logging in');
     logger.error(e);

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ client.on('ready', () =>
 
 client.on('message', (message) =>
 {
-    if(message.content === '!weapons')
+    if(message.content === `${config.prefix}weapons`)
     {
         // Send a list of weapons
         logger.info(`Sending weapons to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
@@ -249,7 +249,7 @@ client.on('message', (message) =>
         });
     }
 
-    if(message.content === '!stages')
+    if(message.content === `${config.prefix}stages`)
     {
         // Send a list of stages
         logger.info(`Sending stages to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
@@ -297,7 +297,7 @@ client.on('message', (message) =>
         });
     }
 
-    if(message.content.startsWith('!randomstage'))
+    if(message.content.startsWith(`${config.prefix}randomstage`))
     {
         logger.info(`Sending random stage to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
         // Get a random stage
@@ -325,7 +325,7 @@ client.on('message', (message) =>
         }
     }
 
-    if(message.content === '!randomweapon')
+    if(message.content === `${config.prefix}randomweapon`)
     {
         logger.info(`Sending random weapon to ${message.member.user.username} in ${message.guild.name} - ${message.channel.name}`);
         weaponsLibrary.getWeapons((err, data) =>
@@ -337,7 +337,7 @@ client.on('message', (message) =>
         });
     }
 
-    if(message.content === '!togglemaps')
+    if(message.content === `${config.prefix}togglemaps`)
     {
         // Make sure that if this is a server, only allow the owner to modify this
         if(message.channel.type === 'text')
@@ -365,7 +365,7 @@ client.on('message', (message) =>
         logger.info(`{On ${message.guild.name} (${message.guild.id})}`);
     }
 
-    if(message.content === '!help')
+    if(message.content === `${config.prefix}help`)
     {
         let msgData = [
             '**Command Usage:**',

--- a/index.js
+++ b/index.js
@@ -370,17 +370,17 @@ client.on('message', (message) =>
         let msgData = [
             '**Command Usage:**',
             '',
-            '__!help__ - Show help',
+            `**${config.prefix}help** - Show help`,
             '',
-            '__!togglemaps__ - Toggle the automatic updates of maps in this channel',
+            `**${config.prefix}togglemaps** - Toggle the automatic updates of maps in this channel`,
             '',
-            '__!weapons__ - List all Splatoon 2 weapons',
+            `**${config.prefix}weapons** - List all Splatoon 2 weapons`,
             '',
-            '__!randomweapon__ - Get a random weapon',
+            `**${config.prefix}randomweapon** - Get a random weapon`,
             '',
-            '__!stages__ - List all Splatoon 2 stages',
+            `**${config.prefix}stages** - List all Splatoon 2 stages`,
             '',
-            '__!randomstage__ [category] - Gets a random stage from the specified category. Options are reg, regular, splat, splatfest, salmon, salmonrun, and station. Defaults to regular.'
+            `**${config.prefix}randomstage** [category] - Gets a random stage from the specified category. Options are reg, regular, splat, splatfest, salmon, salmonrun, and station. Defaults to regular.`
         ];
         message.channel.send(msgData.join("\n")).catch(logger.error);
     }


### PR DESCRIPTION
## Changes
This primarily fixes handling of the token used for the discord bot. The token information has been merged into a `config.json` file that the user creates upon download, and this new configuration file also contains an option for a user-created prefix that the bot will respond to, instead of the default prefix of `!` used prior.
## Updates
This also simplifies the instructions into a much easier `README.md` file, which now contains instructions for a quick setup of the bot, and links to Discord's developer page to help first-time bot creators get a quicker start. This new file also includes full instructions for how to clone the repository and setup a `config.json` file for managing the bot's prefix and token.